### PR TITLE
fix: security config to pass dev-profile creation and encode passwords

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/config/SecurityConfig.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package br.com.gustavoakira.devconnect.adapters.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,10 +25,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/v1/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/v1/dev-profiles").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
@@ -21,7 +21,7 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/v1/dev-profiles/")
+@RequestMapping("/v1/dev-profiles")
 public class DevProfileController {
     @Autowired
     private DevProfileUseCases cases;

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/persistence/repository/devprofile/DevProfileRepositoryImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/persistence/repository/devprofile/DevProfileRepositoryImpl.java
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
@@ -25,11 +26,13 @@ public class DevProfileRepositoryImpl implements IDevProfileRepository {
     private final SpringDataPostgresDevProfileRepository springDataPostgresDevProfileRepository;
 
     private final EntityManager manager;
+    private final PasswordEncoder encoder;
 
-    public DevProfileRepositoryImpl(SpringDataPostgresDevProfileRepository springDataPostgresDevProfileRepository, DevProfileMapper mapper, EntityManager manager) {
+    public DevProfileRepositoryImpl(SpringDataPostgresDevProfileRepository springDataPostgresDevProfileRepository, DevProfileMapper mapper, EntityManager manager, PasswordEncoder encoder) {
         this.springDataPostgresDevProfileRepository = springDataPostgresDevProfileRepository;
         this.mapper = mapper;
         this.manager = manager;
+        this.encoder = encoder;
     }
 
 
@@ -41,6 +44,7 @@ public class DevProfileRepositoryImpl implements IDevProfileRepository {
     @Override
     public DevProfile save(DevProfile profile) throws BusinessException {
         DevProfileEntity entity = mapper.toEntity(profile);
+        entity.setPassword(encoder.encode(profile.getPassword().getValue()));
         return mapper.toDomain(springDataPostgresDevProfileRepository.save(entity));
     }
 

--- a/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/SaveDevProfileUseCase.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/SaveDevProfileUseCase.java
@@ -1,5 +1,6 @@
 package br.com.gustavoakira.devconnect.application.usecases.devprofile;
 
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
 import br.com.gustavoakira.devconnect.application.domain.DevProfile;
 import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.SaveDevProfileCommand;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,5 @@ spring:
     name: devconnect
 server:
   port: 8083
+jwt:
+  secret: sua_chave_super_secreta_de_32+_caracteres

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/persistence/repository/devprofile/DevProfileRepositoryImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/persistence/repository/devprofile/DevProfileRepositoryImplTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,10 +35,12 @@ class DevProfileRepositoryImplTest {
     private DevProfileRepositoryImpl repository;
     @Mock
     private EntityManager manager;
+    @Mock
+    private PasswordEncoder encoder;
 
     @BeforeEach
     void setUp() {
-        repository = new DevProfileRepositoryImpl(springDataPostgresDevProfileRepository, mapper, manager);
+        repository = new DevProfileRepositoryImpl(springDataPostgresDevProfileRepository, mapper, manager, encoder);
     }
 
 
@@ -47,6 +50,7 @@ class DevProfileRepositoryImplTest {
         DevProfile domainProfile = new DevProfile("Akira Uekita","akirauekita2002@gmail.com","Str@ngP4ssword","fasfsdfdsfdsafdfdfsdfsdfsdfdfsdsfdsfsdffd",new Address("Avenida Joao Dias","2048","São Paulo","BR","04724-003"),"https://github.com/Gustavo-Akira","https://www.linkedin.com/in/gustavo-akira-uekita/",new ArrayList<>(),true);
         DevProfileEntity entity = getEntity();
         entity.setId(1L);
+        Mockito.when(encoder.encode(domainProfile.getPassword().getValue())).thenReturn(domainProfile.getPassword().getValue());
         Mockito.when(springDataPostgresDevProfileRepository.save(entity)).thenReturn(entity);
         domainProfile.setId(1L);
 


### PR DESCRIPTION
## 📌 Description
Fixing the security config to not requires authentication on certain routes and encode password
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->
Modify the DevProfileRepository test to mock password encoding
## 📎 Changes
- Adding encode password with bcrypt on dev profile save use case
- Update dev profile path without the final / to pass on the security config
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->
Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
