### PR TITLE
feat: restrict devprofile update and delete to only the logged dev

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/config/JwtProvider.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/config/JwtProvider.java
@@ -29,9 +29,9 @@ public class JwtProvider {
         final Date expiry = new Date(now.getTime() + expirationMillis);
 
         return Jwts.builder()
-                .subject(subject.getEmail())
+                .subject(subject.getId().toString())
                 .issuedAt(now)
-                .claim("id", subject.getId())
+                .claim("email", subject.getEmail())
                 .claim("name", subject.getName())
                 .expiration(expiry)
                 .signWith(key)

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
@@ -15,6 +15,8 @@ import br.com.gustavoakira.devconnect.application.usecases.devprofile.query.Find
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -34,12 +36,12 @@ public class DevProfileController {
 
     @PutMapping
     public ResponseEntity<DevProfileResponse> updateDevProfile(@RequestBody @Valid UpdateDevProfileRequest request) throws BusinessException, EntityNotFoundException {
-        return ResponseEntity.ok().body(DevProfileResponse.fromDomain(cases.updateDevProfileUseCase().execute(request.toCommand())));
+        return ResponseEntity.ok().body(DevProfileResponse.fromDomain(cases.updateDevProfileUseCase().execute(request.toCommand(), getLoggedUserId())));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteDevProfile(@PathVariable Long id) throws EntityNotFoundException {
-        cases.deleteDevProfileUseCase().execute(new DeleteDevProfileCommand(id));
+        cases.deleteDevProfileUseCase().execute(new DeleteDevProfileCommand(id),getLoggedUserId());
         return ResponseEntity.noContent().build();
     }
     @GetMapping("/{id}")
@@ -71,6 +73,10 @@ public class DevProfileController {
         }
 
         return ResponseEntity.ok(toResponse(profiles));
+    }
+
+    private Long getLoggedUserId(){
+        return Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
     }
 
     private PaginatedResult<DevProfileResponse> toResponse(PaginatedResult<DevProfile> domain) {

--- a/src/main/java/br/com/gustavoakira/devconnect/application/domain/exceptions/ForbiddenException.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/domain/exceptions/ForbiddenException.java
@@ -1,0 +1,7 @@
+package br.com.gustavoakira.devconnect.application.domain.exceptions;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/br/com/gustavoakira/devconnect/application/services/devprofile/DeleteDevProfileUseCaseImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/services/devprofile/DeleteDevProfileUseCaseImpl.java
@@ -1,11 +1,14 @@
 package br.com.gustavoakira.devconnect.application.services.devprofile;
 
 import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.ForbiddenException;
 import br.com.gustavoakira.devconnect.application.repository.IDevProfileRepository;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.DeleteDevProfileUseCase;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.DeleteDevProfileCommand;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 public class DeleteDevProfileUseCaseImpl implements DeleteDevProfileUseCase {
@@ -14,7 +17,10 @@ public class DeleteDevProfileUseCaseImpl implements DeleteDevProfileUseCase {
     private IDevProfileRepository repository;
 
     @Override
-    public void execute(DeleteDevProfileCommand command) throws EntityNotFoundException {
-       repository.deleteProfile(command.id());
+    public void execute(DeleteDevProfileCommand command, Long loggedUserId) throws EntityNotFoundException {
+        if(!Objects.equals(command.id(), loggedUserId)){
+            throw new ForbiddenException("Unauthorized action");
+        }
+        repository.deleteProfile(command.id());
     }
 }

--- a/src/main/java/br/com/gustavoakira/devconnect/application/services/devprofile/UpdateDevProfileUseCaseImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/services/devprofile/UpdateDevProfileUseCaseImpl.java
@@ -3,6 +3,7 @@ package br.com.gustavoakira.devconnect.application.services.devprofile;
 import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
 import br.com.gustavoakira.devconnect.application.domain.DevProfile;
 import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.ForbiddenException;
 import br.com.gustavoakira.devconnect.application.domain.value_object.Address;
 import br.com.gustavoakira.devconnect.application.repository.IDevProfileRepository;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.UpdateDevProfileUseCase;
@@ -10,12 +11,17 @@ import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.Up
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Service
 public class UpdateDevProfileUseCaseImpl implements UpdateDevProfileUseCase {
     @Autowired
     private IDevProfileRepository repository;
     @Override
-    public DevProfile execute(UpdateDevProfileCommand command) throws EntityNotFoundException, BusinessException {
+    public DevProfile execute(UpdateDevProfileCommand command, Long loggedId) throws EntityNotFoundException, BusinessException {
+        if(!Objects.equals(command.id(), loggedId)){
+            throw new ForbiddenException("Unauthorized action");
+        }
         final Address address = new Address(
                 command.street(),
                 command.city(),

--- a/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/DeleteDevProfileUseCase.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/DeleteDevProfileUseCase.java
@@ -4,5 +4,5 @@ import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoun
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.DeleteDevProfileCommand;
 
 public interface DeleteDevProfileUseCase {
-    void execute(DeleteDevProfileCommand command) throws EntityNotFoundException;
+    void execute(DeleteDevProfileCommand command, Long loggedUserId) throws EntityNotFoundException;
 }

--- a/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/UpdateDevProfileUseCase.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/usecases/devprofile/UpdateDevProfileUseCase.java
@@ -6,5 +6,5 @@ import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessExce
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.UpdateDevProfileCommand;
 
 public interface UpdateDevProfileUseCase {
-    DevProfile execute(UpdateDevProfileCommand command) throws EntityNotFoundException, BusinessException;
+    DevProfile execute(UpdateDevProfileCommand command, Long loggedId) throws EntityNotFoundException, BusinessException;
 }

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileControllerTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileControllerTest.java
@@ -9,7 +9,6 @@ import br.com.gustavoakira.devconnect.application.domain.value_object.Address;
 import br.com.gustavoakira.devconnect.application.shared.PaginatedResult;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.*;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.DeleteDevProfileCommand;
-import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.UpdateDevProfileCommand;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.filters.DevProfileFilter;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.query.DevProfileFindAllQuery;
 import br.com.gustavoakira.devconnect.application.usecases.devprofile.query.FindDevProfileByIdQuery;
@@ -24,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -71,7 +72,8 @@ class DevProfileControllerTest {
     @BeforeEach
     void setup() throws BusinessException {
         MockitoAnnotations.openMocks(this);
-
+        final var auth = new UsernamePasswordAuthenticationToken("1", null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
         Mockito.when(useCases.saveDevProfileUseCase()).thenReturn(saveUseCase);
         Mockito.when(useCases.updateDevProfileUseCase()).thenReturn(updateDevProfileUseCase);
         Mockito.when(useCases.deleteDevProfileUseCase()).thenReturn(deleteDevProfileUseCase);
@@ -131,7 +133,7 @@ class DevProfileControllerTest {
 
             final DevProfile updatedProfile = createMockDevProfile();
 
-            Mockito.when(updateDevProfileUseCase.execute(any())).thenReturn(updatedProfile);
+            Mockito.when(updateDevProfileUseCase.execute(any(),any())).thenReturn(updatedProfile);
 
             mockMvc.perform(put("/v1/dev-profiles")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -149,7 +151,7 @@ class DevProfileControllerTest {
             mockMvc.perform(delete("/v1/dev-profiles/1"))
                     .andExpect(status().isNoContent());
 
-            Mockito.verify(deleteDevProfileUseCase).execute(new DeleteDevProfileCommand(1L));
+            Mockito.verify(deleteDevProfileUseCase).execute(new DeleteDevProfileCommand(1L),1L);
         }
     }
 

--- a/src/test/java/br/com/gustavoakira/devconnect/application/services/devprofile/DeleteDevProfileUseCaseImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/application/services/devprofile/DeleteDevProfileUseCaseImplTest.java
@@ -1,0 +1,50 @@
+package br.com.gustavoakira.devconnect.application.services.devprofile;
+
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.ForbiddenException;
+import br.com.gustavoakira.devconnect.application.repository.IDevProfileRepository;
+import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.DeleteDevProfileCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteDevProfileUseCaseImplTest {
+
+    @InjectMocks
+    private DeleteDevProfileUseCaseImpl useCase;
+
+    @Mock
+    private IDevProfileRepository repository;
+
+
+    @Nested
+    class DeleteWithSuccess{
+        @Test
+        void shouldDeleteWithSuccessWhenDevProfileExistsAndLoggedUserIsEqual() throws EntityNotFoundException {
+            Mockito.doNothing().when(repository).deleteProfile(1L);
+            useCase.execute(new DeleteDevProfileCommand(1L),1L);
+        }
+    }
+    @Nested
+    class DeleteWithException{
+        @Test
+        void shouldThrowEntityNotFoundExceptionWhenDevProfileNotFound() throws EntityNotFoundException {
+            Mockito.doThrow(new EntityNotFoundException("")).when(repository).deleteProfile(1L);
+            assertThrows(EntityNotFoundException.class,()->useCase.execute(new DeleteDevProfileCommand(1L),1L));
+        }
+
+        @Test
+        void shouldThrowForbiddenExceptionWhenDeletedIdIsDifferentFromLoggedUserId() {
+            assertThrows(ForbiddenException.class,()->useCase.execute(new DeleteDevProfileCommand(1L),2L));
+        }
+    }
+}

--- a/src/test/java/br/com/gustavoakira/devconnect/application/services/devprofile/UpdateDevProfileUseCaseImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/application/services/devprofile/UpdateDevProfileUseCaseImplTest.java
@@ -1,0 +1,67 @@
+package br.com.gustavoakira.devconnect.application.services.devprofile;
+
+import br.com.gustavoakira.devconnect.adapters.inbound.controller.devprofile.dto.UpdateDevProfileRequest;
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.ForbiddenException;
+import br.com.gustavoakira.devconnect.application.repository.IDevProfileRepository;
+import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.DeleteDevProfileCommand;
+import br.com.gustavoakira.devconnect.application.usecases.devprofile.command.UpdateDevProfileCommand;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@ExtendWith(MockitoExtension.class)
+class UpdateDevProfileUseCaseImplTest {
+    @InjectMocks
+    private UpdateDevProfileUseCaseImpl useCase;
+
+    @Mock
+    private IDevProfileRepository repository;
+
+    @Nested
+    class UpdateWithSuccess{
+        @Test
+        void shouldUpdateDevProfileWithSuccess() throws BusinessException {
+            Mockito.when(repository.update(Mockito.any())).thenReturn(Mockito.any());
+            assertDoesNotThrow(()->useCase.execute(getMockCommand(),1L));
+        }
+    }
+
+    @Nested
+    class UpdateWithException{
+        @Test
+        void shouldThrowBusinessExceptionWhenDevProfileWasModifiedDirectlyOnDB() throws BusinessException {
+            Mockito.when(repository.update(Mockito.any())).thenThrow(BusinessException.class);
+            assertThrows(BusinessException.class,()->useCase.execute(getMockCommand(),1L));
+        }
+
+        @Test
+        void shouldThrowForbiddenExceptionWhenDeletedIdIsDifferentFromLoggedUserId() {
+            assertThrows(ForbiddenException.class,()->useCase.execute(getMockCommand(),2L));
+        }
+    }
+
+    private UpdateDevProfileCommand getMockCommand(){
+        final UpdateDevProfileRequest request = new UpdateDevProfileRequest(1L, "Gustavo Akira",
+                "gustavo@email.com",
+                "123456",
+                "Rua Teste",
+                "São Paulo",
+                "SP",
+                "01234-567",
+                "BR",
+                "https://github.com/gustavo",
+                "https://linkedin.com/in/gustavo",
+                "Sou desenvolvedor Java",
+                List.of("Java", "Spring Boot"));
+        return request.toCommand();
+    }
+}


### PR DESCRIPTION
## 📌 Description
Restrict update and delete usecases to only who own that profile can change or delete it. (loggedUserId = DevProfileId)
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->
Adding ForbiddenException test cases on update and delete devprofile use cases
## 📎 Changes
Adding restriction on usecases that delete and update devprofile (LoggedUserId = DevProfileId)
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->
Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
