### PR TITLE
feat: change docker file to be agnostic of profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY ./build/libs/devconnect-*.jar app.jar
 
-EXPOSE 8083
+EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENV SPRING_PROFILES_ACTIVE=docker
+
+ENTRYPOINT ["java", "-jar", "app.jar","--spring.profiles.active=${SPRING_PROFILES_ACTIVE}"]

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/config/JwtProvider.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/config/JwtProvider.java
@@ -47,6 +47,7 @@ public class JwtProvider {
             parseClaims(token);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
+            System.out.println(e.getMessage());
             return false;
         }
     }

--- a/src/main/java/br/com/gustavoakira/devconnect/application/services/auth/TokenGrantUseCaseImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/services/auth/TokenGrantUseCaseImpl.java
@@ -35,7 +35,7 @@ public class TokenGrantUseCaseImpl implements TokenGrantUseCase {
         if (!encoder.matches(command.password(), profile.getPassword().getValue())) {
             throw new BusinessException("Invalid credentials");
         }
-        final long expiresIn = 2 * 60 * 60L;
+        final long expiresIn = 2 * 60 * 60L * 1000;
         final String token = jwtProvider.generateToken(profile,expiresIn);
 
         return new TokenGrantResponse(token, expiresIn);

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,9 @@
+db:
+  config:
+    username: devuser
+    password: devpass
+    url: jdbc:postgresql://postgres:5432/devconnect
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,6 @@ spring:
   application:
     name: devconnect
 server:
-  port: 8083
+  port: 8080
 jwt:
   secret: sua_chave_super_secreta_de_32+_caracteres


### PR DESCRIPTION
## 📌 Description
Change docker file and adding profiles to make it agnostic of which spring profile is called
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->

## 📎 Changes
- Adding docker profile to represents profile
- change port to be the default of spring 8080
- changing expire time from 7200 miliseconds to 7200000
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->
Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
