### PR TITLE
refact: using cookie with httpOnly to improve security instead of return jwt

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/AuthController.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/AuthController.java
@@ -1,13 +1,14 @@
 package br.com.gustavoakira.devconnect.adapters.inbound.controller.auth;
 
 import br.com.gustavoakira.devconnect.adapters.inbound.controller.auth.dto.TokenRequest;
-import br.com.gustavoakira.devconnect.adapters.inbound.controller.auth.dto.TokenResponse;
 import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
 import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
 import br.com.gustavoakira.devconnect.application.usecases.auth.TokenGrantUseCase;
 import br.com.gustavoakira.devconnect.application.usecases.auth.response.TokenGrantResponse;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,8 +23,18 @@ public class AuthController {
     private TokenGrantUseCase tokenGrantUseCase;
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody @Valid TokenRequest request) throws BusinessException, EntityNotFoundException {
+    public ResponseEntity<Void> login(@RequestBody @Valid TokenRequest request) throws BusinessException, EntityNotFoundException {
         final TokenGrantResponse tokenGrantResponse = tokenGrantUseCase.execute(request.toCommand());
-        return ResponseEntity.ok(new TokenResponse(tokenGrantResponse.token(), tokenGrantResponse.expiresIn()));
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE,makeAuthCookieWithHttpOnly(tokenGrantResponse).toString()).build();
     }
+
+    private ResponseCookie makeAuthCookieWithHttpOnly(TokenGrantResponse tokenGrantResponse){
+        return ResponseCookie.from("jwt", tokenGrantResponse.token())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(tokenGrantResponse.expiresIn())
+                .build();
+    };
 }

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/dto/TokenResponse.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/dto/TokenResponse.java
@@ -1,4 +1,0 @@
-package br.com.gustavoakira.devconnect.adapters.inbound.controller.auth.dto;
-
-public record TokenResponse(String access_token, Long expires_in) {}
-

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/AuthControllerTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/auth/AuthControllerTest.java
@@ -54,7 +54,6 @@ public class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(tokenRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.access_token").value("fake-jwt-token"))
-                .andExpect(jsonPath("$.expires_in").value(3600));
+                .andExpect(cookie().exists("jwt"));
     }
 }


### PR DESCRIPTION


## 📌 Description
Refactoring use of jwt from authorization header to cookie with httpOnly to improve security against XSS attacks
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->

## 📎 Changes
- Change filter for using cookie with jwt httpOnly and security
- Instead of return jwt on body setting  jwt cookie on response
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->
Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
