### PR TITLE
feat: add profile endpoint

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileController.java
@@ -50,6 +50,11 @@ public class DevProfileController {
         return ResponseEntity.ok(DevProfileResponse.fromDomain(profile));
     }
 
+    @GetMapping("/profile")
+    public ResponseEntity<DevProfileResponse> getProfile() throws BusinessException, EntityNotFoundException {
+        return ResponseEntity.ok(DevProfileResponse.fromDomain(cases.findDevProfileByIdUseCase().execute(new FindDevProfileByIdQuery(getLoggedUserId()))));
+    }
+
     @GetMapping
     public ResponseEntity<PaginatedResult<DevProfileResponse>> findAll(
             @RequestParam(defaultValue = "0") Integer number,

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileControllerTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/inbound/controller/devprofile/DevProfileControllerTest.java
@@ -3,6 +3,7 @@ package br.com.gustavoakira.devconnect.adapters.inbound.controller.devprofile;
 import br.com.gustavoakira.devconnect.adapters.config.JwtProvider;
 import br.com.gustavoakira.devconnect.adapters.inbound.controller.devprofile.dto.SaveDevProfileRequest;
 import br.com.gustavoakira.devconnect.adapters.inbound.controller.devprofile.dto.UpdateDevProfileRequest;
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
 import br.com.gustavoakira.devconnect.application.domain.DevProfile;
 import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
 import br.com.gustavoakira.devconnect.application.domain.value_object.Address;
@@ -296,6 +297,20 @@ class DevProfileControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.content[0].name", is("Gustavo Akira")))
                     .andExpect(jsonPath("$.totalElements", is(1)));
+        }
+    }
+
+    @Nested
+    class GetProfile{
+        @Test
+        void shouldGetProfileWhenLogged() throws Exception {
+            final DevProfile profile = createMockDevProfile();
+
+            Mockito.when(useCases.findDevProfileByIdUseCase().execute(new FindDevProfileByIdQuery(profile.getId()))).thenReturn(profile);
+            mockMvc.perform(get("/v1/dev-profiles/profile"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id", is(1)))
+                    .andExpect(jsonPath("$.name", is("Gustavo Akira")));
         }
     }
 


### PR DESCRIPTION
## 📌 Description
Adding profile endpoint to get logged devprofile. And with this the front end dont need to know the jwt to get the profile.
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->

## 📎 Changes
- Adding profile endpoint to get logged devprofile
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->
Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
