### PR TITLE
feat: adding complete password recovery usecase

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImpl.java
@@ -1,0 +1,33 @@
+package br.com.gustavoakira.devconnect.application.services.passwordrecovery;
+
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.User;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
+import br.com.gustavoakira.devconnect.application.repository.IPasswordRecoveryRepository;
+import br.com.gustavoakira.devconnect.application.repository.IUserRepository;
+import br.com.gustavoakira.devconnect.application.usecases.passwordrecovery.CompletePasswordRecoveryUseCase;
+import br.com.gustavoakira.devconnect.application.usecases.passwordrecovery.command.CompletePasswordRecoveryCommand;
+
+import java.time.Instant;
+
+public class CompletePasswordRecoveryUseCaseImpl implements CompletePasswordRecoveryUseCase {
+
+    private final IPasswordRecoveryRepository repository;
+    private final IUserRepository userRepository;
+
+    public CompletePasswordRecoveryUseCaseImpl(IPasswordRecoveryRepository repository, IUserRepository userRepository) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public PasswordRecovery execute(CompletePasswordRecoveryCommand command) throws BusinessException, EntityNotFoundException {
+        PasswordRecovery recovery = repository.findByToken(command.token());
+        User user = userRepository.findById(recovery.getUserId());
+        user.changePassword(command.newPassword());
+        recovery.markAsUsed(Instant.now());
+        userRepository.save(user);
+        return repository.save(recovery);
+    }
+}

--- a/src/main/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImpl.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImpl.java
@@ -23,8 +23,8 @@ public class CompletePasswordRecoveryUseCaseImpl implements CompletePasswordReco
 
     @Override
     public PasswordRecovery execute(CompletePasswordRecoveryCommand command) throws BusinessException, EntityNotFoundException {
-        PasswordRecovery recovery = repository.findByToken(command.token());
-        User user = userRepository.findById(recovery.getUserId());
+        final PasswordRecovery recovery = repository.findByToken(command.token());
+        final User user = userRepository.findById(recovery.getUserId());
         user.changePassword(command.newPassword());
         recovery.markAsUsed(Instant.now());
         userRepository.save(user);

--- a/src/main/java/br/com/gustavoakira/devconnect/application/usecases/passwordrecovery/CompletePasswordRecoveryUseCase.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/usecases/passwordrecovery/CompletePasswordRecoveryUseCase.java
@@ -1,0 +1,10 @@
+package br.com.gustavoakira.devconnect.application.usecases.passwordrecovery;
+
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
+import br.com.gustavoakira.devconnect.application.usecases.passwordrecovery.command.CompletePasswordRecoveryCommand;
+
+public interface CompletePasswordRecoveryUseCase {
+    PasswordRecovery execute(CompletePasswordRecoveryCommand command) throws BusinessException, EntityNotFoundException;
+}

--- a/src/main/java/br/com/gustavoakira/devconnect/application/usecases/passwordrecovery/command/CompletePasswordRecoveryCommand.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/usecases/passwordrecovery/command/CompletePasswordRecoveryCommand.java
@@ -1,0 +1,4 @@
+package br.com.gustavoakira.devconnect.application.usecases.passwordrecovery.command;
+
+public record CompletePasswordRecoveryCommand(String newPassword, String token) {
+}

--- a/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
@@ -1,0 +1,113 @@
+package br.com.gustavoakira.devconnect.application.services.passwordrecovery;
+
+import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.User;
+import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;
+import br.com.gustavoakira.devconnect.application.repository.IPasswordRecoveryRepository;
+import br.com.gustavoakira.devconnect.application.repository.IUserRepository;
+import br.com.gustavoakira.devconnect.application.usecases.passwordrecovery.command.CompletePasswordRecoveryCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CompletePasswordRecoveryUseCaseImplTest {
+
+    private IPasswordRecoveryRepository recoveryRepository;
+    private IUserRepository userRepository;
+
+    private CompletePasswordRecoveryUseCaseImpl useCase;
+
+    @BeforeEach
+    void setup() {
+        recoveryRepository = Mockito.mock(IPasswordRecoveryRepository.class);
+        userRepository = Mockito.mock(IUserRepository.class);
+        useCase = new CompletePasswordRecoveryUseCaseImpl(recoveryRepository, userRepository);
+    }
+
+    private PasswordRecovery createValidRecovery() {
+        return new PasswordRecovery(
+                1L,
+                "token123",
+                10L,
+                Instant.now().plusSeconds(300)
+        );
+    }
+
+    private User createUser() throws BusinessException {
+        return new User(
+                10L,
+                "oldPassword",
+                "gustavo@email.com",
+                true
+        );
+    }
+
+    @Test
+    void shouldCompletePasswordRecoverySuccessfully() throws Exception {
+
+        PasswordRecovery recovery = createValidRecovery();
+        User user = createUser();
+
+        when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
+        when(userRepository.findById(10L)).thenReturn(user);
+        when(recoveryRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        CompletePasswordRecoveryCommand command =
+                new CompletePasswordRecoveryCommand( "newPassword","token123");
+
+        PasswordRecovery result = useCase.execute(command);
+
+        assertNotNull(result);
+        assertTrue(result.isUsed());
+
+        verify(userRepository).save(user);
+        verify(recoveryRepository).save(recovery);
+    }
+
+    @Test
+    void shouldThrowWhenTokenAlreadyUsed() throws Exception {
+
+        PasswordRecovery recovery = createValidRecovery();
+        recovery.markAsUsed(Instant.now());
+
+        when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
+        when(userRepository.findById(any())).thenReturn(createUser());
+        CompletePasswordRecoveryCommand command =
+                new CompletePasswordRecoveryCommand("newPassword","token123");
+
+        assertThrows(BusinessException.class,
+                () -> useCase.execute(command));
+
+        verify(userRepository, never()).save(any());
+        verify(recoveryRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldThrowWhenTokenExpired() throws Exception {
+
+        PasswordRecovery recovery = new PasswordRecovery(
+                1L,
+                "token123",
+                10L,
+                Instant.now().minusSeconds(10)
+        );
+
+        when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
+        when(userRepository.findById(10L)).thenReturn(createUser());
+
+        CompletePasswordRecoveryCommand command =
+                new CompletePasswordRecoveryCommand( "newPassword","token123");
+
+        assertThrows(BusinessException.class,
+                () -> useCase.execute(command));
+
+        verify(userRepository, never()).save(any());
+        verify(recoveryRepository, never()).save(any());
+    }
+}

--- a/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
@@ -1,6 +1,5 @@
 package br.com.gustavoakira.devconnect.application.services.passwordrecovery;
 
-import br.com.gustavoakira.devconnect.adapters.outbound.exceptions.EntityNotFoundException;
 import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
 import br.com.gustavoakira.devconnect.application.domain.User;
 import br.com.gustavoakira.devconnect.application.domain.exceptions.BusinessException;

--- a/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/application/services/passwordrecovery/CompletePasswordRecoveryUseCaseImplTest.java
@@ -50,17 +50,17 @@ class CompletePasswordRecoveryUseCaseImplTest {
     @Test
     void shouldCompletePasswordRecoverySuccessfully() throws Exception {
 
-        PasswordRecovery recovery = createValidRecovery();
-        User user = createUser();
+        final PasswordRecovery recovery = createValidRecovery();
+        final User user = createUser();
 
         when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
         when(userRepository.findById(10L)).thenReturn(user);
         when(recoveryRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        CompletePasswordRecoveryCommand command =
+        final CompletePasswordRecoveryCommand command =
                 new CompletePasswordRecoveryCommand( "newPassword","token123");
 
-        PasswordRecovery result = useCase.execute(command);
+        final PasswordRecovery result = useCase.execute(command);
 
         assertNotNull(result);
         assertTrue(result.isUsed());
@@ -72,12 +72,12 @@ class CompletePasswordRecoveryUseCaseImplTest {
     @Test
     void shouldThrowWhenTokenAlreadyUsed() throws Exception {
 
-        PasswordRecovery recovery = createValidRecovery();
+        final PasswordRecovery recovery = createValidRecovery();
         recovery.markAsUsed(Instant.now());
 
         when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
         when(userRepository.findById(any())).thenReturn(createUser());
-        CompletePasswordRecoveryCommand command =
+        final CompletePasswordRecoveryCommand command =
                 new CompletePasswordRecoveryCommand("newPassword","token123");
 
         assertThrows(BusinessException.class,
@@ -90,7 +90,7 @@ class CompletePasswordRecoveryUseCaseImplTest {
     @Test
     void shouldThrowWhenTokenExpired() throws Exception {
 
-        PasswordRecovery recovery = new PasswordRecovery(
+        final PasswordRecovery recovery = new PasswordRecovery(
                 1L,
                 "token123",
                 10L,
@@ -100,7 +100,7 @@ class CompletePasswordRecoveryUseCaseImplTest {
         when(recoveryRepository.findByToken("token123")).thenReturn(recovery);
         when(userRepository.findById(10L)).thenReturn(createUser());
 
-        CompletePasswordRecoveryCommand command =
+        final CompletePasswordRecoveryCommand command =
                 new CompletePasswordRecoveryCommand( "newPassword","token123");
 
         assertThrows(BusinessException.class,


### PR DESCRIPTION
## 📌 Description

Implement the `CompletePasswordRecoveryUseCase`, responsible for finalizing the password reset flow.

This use case validates the recovery token, updates the user's password, marks the token as used, and persists the changes.

It completes the password recovery lifecycle previously introduced with the request recovery use case.

---

## 🧪 Realized Tests

- [x] Local tests  
- [x] All tests passed  

### Covered scenarios

- Successful password reset
- Token not found
- Token already used
- Token expired
- Password successfully updated
- Token marked as used after completion

---

## 📎 Changes

### Application Layer

Added:

- `CompletePasswordRecoveryUseCase` (interface)
- `CompletePasswordRecoveryCommand`
- `CompletePasswordRecoveryUseCaseImpl`

### Business Flow Implemented

1. Retrieve recovery by token
2. Retrieve user by recovery.userId
3. Change user password
4. Mark recovery token as used
5. Persist updated user
6. Persist updated recovery

```java
PasswordRecovery recovery = repository.findByToken(command.token());
User user = userRepository.findById(recovery.getUserId());

user.changePassword(command.newPassword());
userRepository.save(user);

recovery.markAsUsed(Instant.now());
return repository.save(recovery);