### PR TITLE
feat: add send password recovery requested event

### DIFF
--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisher.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisher.java
@@ -1,0 +1,37 @@
+package br.com.gustavoakira.devconnect.adapters.outbound.publishers.passwordrecovery.requested;
+
+import br.com.gustavoakira.devconnect.adapters.config.TopicProperties;
+import br.com.gustavoakira.devconnect.adapters.outbound.publishers.passwordrecovery.requested.event.PasswordRecoveryRequestEvent;
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.User;
+import br.com.gustavoakira.devconnect.application.publishers.PasswordRecoveryRequestPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaPasswordRecoveryRequestPublisher implements PasswordRecoveryRequestPublisher {
+
+
+    private final Logger logger = LoggerFactory.getLogger(KafkaPasswordRecoveryRequestPublisher.class);
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final TopicProperties topicProperties;
+
+    public KafkaPasswordRecoveryRequestPublisher(KafkaTemplate<String, Object> kafkaTemplate, TopicProperties topicProperties) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.topicProperties = topicProperties;
+    }
+
+    @Override
+    public void send(PasswordRecovery recovery, User user) {
+        final PasswordRecoveryRequestEvent event = new PasswordRecoveryRequestEvent(recovery.getUserId(), "http://localhost:8090"+recovery.getToken(), user.getEmail(), recovery.getExpiresAt());
+        this.kafkaTemplate.send(topicProperties.getTopicName("auth.password-recovery.requested"), event).whenComplete(((_, ex) -> {
+            if (ex != null) {
+                logger.error("Failed to publish event for {}: {}", event.email(), ex.getMessage());
+            } else {
+                logger.info("Event published for email {} ", event.email());
+            }
+        }));
+    }
+}

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisher.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisher.java
@@ -7,6 +7,7 @@ import br.com.gustavoakira.devconnect.application.domain.User;
 import br.com.gustavoakira.devconnect.application.publishers.PasswordRecoveryRequestPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,9 @@ public class KafkaPasswordRecoveryRequestPublisher implements PasswordRecoveryRe
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final TopicProperties topicProperties;
 
+    @Value("${app.auth.recovery_link_base_url}")
+    private String baseUrl;
+
     public KafkaPasswordRecoveryRequestPublisher(KafkaTemplate<String, Object> kafkaTemplate, TopicProperties topicProperties) {
         this.kafkaTemplate = kafkaTemplate;
         this.topicProperties = topicProperties;
@@ -25,7 +29,7 @@ public class KafkaPasswordRecoveryRequestPublisher implements PasswordRecoveryRe
 
     @Override
     public void send(PasswordRecovery recovery, User user) {
-        final PasswordRecoveryRequestEvent event = new PasswordRecoveryRequestEvent(recovery.getUserId(), "http://localhost:8090"+recovery.getToken(), user.getEmail(), recovery.getExpiresAt());
+        final PasswordRecoveryRequestEvent event = new PasswordRecoveryRequestEvent(recovery.getUserId(), baseUrl+"/"+recovery.getToken(), user.getEmail(), recovery.getExpiresAt());
         this.kafkaTemplate.send(topicProperties.getTopicName("auth.password-recovery.requested"), event).whenComplete(((_, ex) -> {
             if (ex != null) {
                 logger.error("Failed to publish event for {}: {}", event.email(), ex.getMessage());

--- a/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/event/PasswordRecoveryRequestEvent.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/event/PasswordRecoveryRequestEvent.java
@@ -1,0 +1,12 @@
+package br.com.gustavoakira.devconnect.adapters.outbound.publishers.passwordrecovery.requested.event;
+
+import java.time.Instant;
+
+public record PasswordRecoveryRequestEvent(
+        Long userId,
+        String link,
+        String email,
+        Instant expiresIn
+){
+
+}

--- a/src/main/java/br/com/gustavoakira/devconnect/application/publishers/PasswordRecoveryRequestPublisher.java
+++ b/src/main/java/br/com/gustavoakira/devconnect/application/publishers/PasswordRecoveryRequestPublisher.java
@@ -1,0 +1,8 @@
+package br.com.gustavoakira.devconnect.application.publishers;
+
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.User;
+
+public interface PasswordRecoveryRequestPublisher {
+    void send(PasswordRecovery recovery, User user);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,8 @@ spring:
     hibernate:
       ddl-auto: update
 app:
+  auth:
+    recovery_link_base_url: http://localhost:5173
   kafka:
     server: localhost:9092
     client_id: devconnect-service

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -8,6 +8,8 @@ spring:
     hibernate:
       ddl-auto: update
 app:
+  auth:
+    recovery_link_base_url: http://localhost:5173
   kafka:
     server: kafka:9092
     client_id: devconnect-service

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -5,6 +5,8 @@ spring:
 jwt:
   secret: sua_chave_super_secreta_de_32+_caracteres
 app:
+  auth:
+    recovery_link_base_url: http://localhost:5173
   kafka:
     server: localhost:9092
     client_id: devconnect-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,9 @@ app:
         retention-ms: 604800000
         cleanup-policy: delete
         create-dlt: true
+      - name: auth.password-recovery.requested.v1
+        partitions: 3
+        replicas: 1
+        retention-ms: 604800000
+        cleanup-policy: delete
+        create-dlt: true

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisherTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisherTest.java
@@ -48,11 +48,11 @@ class KafkaPasswordRecoveryRequestPublisherTest {
 
         publisher.send(recovery, user);
 
-        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        final ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
 
         verify(kafkaTemplate).send(eq("recovery-topic"), eventCaptor.capture());
 
-        Object capturedEvent = eventCaptor.getValue();
+        final Object capturedEvent = eventCaptor.getValue();
         assertThat(capturedEvent).isNotNull();
     }
 

--- a/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisherTest.java
+++ b/src/test/java/br/com/gustavoakira/devconnect/adapters/outbound/publishers/passwordrecovery/requested/KafkaPasswordRecoveryRequestPublisherTest.java
@@ -1,0 +1,81 @@
+package br.com.gustavoakira.devconnect.adapters.outbound.publishers.passwordrecovery.requested;
+
+import br.com.gustavoakira.devconnect.adapters.config.TopicProperties;
+import br.com.gustavoakira.devconnect.application.domain.PasswordRecovery;
+import br.com.gustavoakira.devconnect.application.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class KafkaPasswordRecoveryRequestPublisherTest {
+
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    private TopicProperties topicProperties;
+    private KafkaPasswordRecoveryRequestPublisher publisher;
+
+    @BeforeEach
+    void setup() {
+        kafkaTemplate = mock(KafkaTemplate.class);
+        topicProperties = mock(TopicProperties.class);
+        publisher = new KafkaPasswordRecoveryRequestPublisher(kafkaTemplate, topicProperties);
+    }
+
+    @Test
+    void shouldPublishPasswordRecoveryEventSuccessfully() {
+        final PasswordRecovery recovery = mock(PasswordRecovery.class);
+        final User user = mock(User.class);
+
+        when(recovery.getUserId()).thenReturn(12L);
+        when(recovery.getToken()).thenReturn("/token-123");
+        when(recovery.getExpiresAt()).thenReturn(Instant.now());
+        when(user.getEmail()).thenReturn("user@email.com");
+        when(topicProperties.getTopicName("auth.password-recovery.requested"))
+                .thenReturn("recovery-topic");
+
+        final CompletableFuture<SendResult<String, Object>> future =
+                CompletableFuture.completedFuture(mock(SendResult.class));
+
+        when(kafkaTemplate.send(eq("recovery-topic"), any()))
+                .thenReturn(future);
+
+        publisher.send(recovery, user);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+
+        verify(kafkaTemplate).send(eq("recovery-topic"), eventCaptor.capture());
+
+        Object capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent).isNotNull();
+    }
+
+    @Test
+    void shouldHandleErrorWhenPublishingFails() {
+        final PasswordRecovery recovery = mock(PasswordRecovery.class);
+        final User user = mock(User.class);
+
+        when(recovery.getUserId()).thenReturn(12L);
+        when(recovery.getToken()).thenReturn("/token-123");
+        when(recovery.getExpiresAt()).thenReturn(Instant.now());
+        when(user.getEmail()).thenReturn("user@email.com");
+        when(topicProperties.getTopicName("auth.password-recovery.requested"))
+                .thenReturn("recovery-topic");
+
+        final CompletableFuture<SendResult<String, Object>> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Kafka error"));
+
+        when(kafkaTemplate.send(eq("recovery-topic"), any()))
+                .thenReturn(future);
+
+        publisher.send(recovery, user);
+
+        verify(kafkaTemplate).send(eq("recovery-topic"), any());
+    }
+}


### PR DESCRIPTION
## 📌 Description

This PR adds the publishing of a `PasswordRecoveryRequestedEvent` when a password recovery request is created.

After successfully creating the password recovery request, the application now dispatches a kafka event, enabling other systems (e.g., notifications, auditing, async integrations) to react without coupling to the core use case.

This change aligns the flow with the project's event-driven architecture while keeping the external API contract unchanged.

---

## 🧪 Realized Tests

- [x] Local tests
- [x] All tests passed

### Relevant Tests

- Verified password recovery request creation flow
- Verified event publishing after successful request creation
- Ensured no regressions in existing recovery flow

---

## 📎 Changes

- Publish `PasswordRecoveryRequestedEvent` after successful password recovery request creation
- Add event object to the outbound infrastructure layer
- Implement/configure event publisher in the outbound infrastructure layer
- Update the corresponding use case to dispatch the event

---

## 🧩 Issues

Closes #

---

## ⚠️ Checklist

- [x] The code is in the same pattern of the project
- [x] Update the docs (Only if needed)

---

## 📝 Comments

No breaking changes.

The external API contract remains unchanged.  
This PR only introduces internal event publishing to improve extensibility and maintain separation of concerns.